### PR TITLE
Fix compatibility errors

### DIFF
--- a/modules/karoo_gp_base_class.py
+++ b/modules/karoo_gp_base_class.py
@@ -2061,7 +2061,7 @@ class Base_GP(object):
 		
 		if self.display == 'i': print ('\t \033[36mwith nodes\033[1m', branch, '\033[0;0m\033[36mchosen for mutation\033[0;0m')
 		
-		return branch
+		return branch.astype(int)
 		
 	
 	def fx_evolve_branch_insert(self, tree, branch):


### PR DESCRIPTION
If you try to run Karoo GP, you will get this error:
```
Traceback (most recent call last):
  File "karoo_gp.py", line 251, in <module>
    gp.fx_karoo_gp(kernel, tree_type, tree_depth_base, tree_depth_max, tree_depth_min, tree_pop_max, gen_max, tourn_size, filename, evolve_repro, evolve_point, evolve_branch, evolve_cross, display, precision, swim, mode)
  File "modules/karoo_gp_base_class.py", line 201, in fx_karoo_gp
    self.fx_nextgen_branch_mutate() # method 3 - Branch Mutation
  File "modules/karoo_gp_base_class.py", line 1765, in fx_nextgen_branch_mutate
    tourn_winner = self.fx_evolve_grow_mutate(tourn_winner, branch)
  File "modules/karoo_gp_base_class.py", line 1970, in fx_evolve_grow_mutate
    tree = self.fx_evolve_branch_insert(tree, branch) # insert new 'branch' at point of mutation 'branch_top' in tourn_winner 'tree'
  File "modules/karoo_gp_base_class.py", line 2091, in fx_evolve_branch_insert
    tree = np.delete(tree, branch[1:], axis = 1) # delete all nodes beneath point of mutation ('branch_top')
  File "<__array_function__ internals>", line 6, in delete
  File "/usr/local/lib/python3.6/dist-packages/numpy/lib/function_base.py", line 4406, in delete
    keep[obj,] = False
IndexError: arrays used as indices must be of integer (or boolean) type
```
This happens because `branch` variable is a NumPy array filled with elements of type `sympy.core.numbers.Integer`. NumPy doesn't properly recognize them as integers, so they must be explicitly converted to integers.