### PR TITLE
Fix output dir path.

### DIFF
--- a/karoo_gp/base_class.py
+++ b/karoo_gp/base_class.py
@@ -551,10 +551,13 @@ class Base_GP(object):
         self.tf_device_log = False  # TF device usage logging (for debugging)
 
         ### PART 4 - create a unique directory and initialise all .csv files ###
-        self.datetime = datetime.now().strftime('%Y-%m-%d_%H-%M-%S')
+        self.datetime = datetime.now().strftime('%Y-%m-%d_%H-%M-%S-%f')
+        basename = os.path.basename(filename)  # extract the filename (if any)
+        root, ext = os.path.splitext(basename)  # split root from extension
         # generate a unique directory name
-        self.path = os.path.join(os.getcwd(), 'runs', filename.split('.')[0] +
-                                 '_' + self.datetime + '/')
+        self.path = os.path.join(os.getcwd(), 'runs',
+                                 root + '_' + self.datetime + '/')
+
         if not os.path.isdir(self.path):
             os.makedirs(self.path)  # make a unique directory
 


### PR DESCRIPTION
This PR supersedes #37 and fixes the same two issues:

1. correctly handles filename that include paths, possibly containing additional `.`s
2. adds ms to the timestamp to avoid conflicts when two runs are execute within the same second
