### PR TITLE
Fix seed initialization.

### DIFF
--- a/karoo-gp.py
+++ b/karoo-gp.py
@@ -311,6 +311,8 @@ if len(sys.argv) < 3:
     # pause at the (d)esktop when complete, awaiting further
     # user interaction; or terminate in (s)erver mode
     mode = 'd'
+    # TODO: allow the user to enter a seed
+    seed = None
 
 
 #++++++++++++++++++++++++++++++++++++++++++

--- a/karoo_gp/base_class.py
+++ b/karoo_gp/base_class.py
@@ -169,9 +169,12 @@ class Base_GP(object):
         self.precision = precision  # the number of floating points for the round function in 'fx_fitness_eval'
         self.swim = swim  # pass along the gene_pool restriction methodology
         self.mode = mode  # mode is engaged in fit()
-        # initialize RNG with the given seed
+
+        # initialize RNG(s) with the given seed
         self.seed = seed
-        self.rng = np.random.default_rng(seed)
+        self.rng = np.random.default_rng(seed)  # this is used by Karoo
+        np.random.seed(seed)  # this is used by sklearn while classifying
+        tf.set_random_seed(seed)  # this is not used, but set it just in case
 
         ### PART 2 - construct first generation of Trees ###
         self.fx_data_load(filename)


### PR DESCRIPTION
This PR fixes seed initialization which is a prerequisite for test reproducibility.

Even after using the new RNG (see #50) some tests were not producing consistent results.   The failure seemed to only affect the classification kernel, and after several tests I was able to fix the issue by initializing the global `np.random` seed  using `np.random.seed`.  Apparently this affects `sklearn`, and after setting it to the given seed I was able to have consistent results in the tests (see also this [SO thread](https://stackoverflow.com/questions/40750394/how-to-seed-the-random-number-generator-for-scikit-learn)).

Grant also suggested to pass the RNG to [sklearn.model_selection.train_test_split](https://scikit-learn.org/stable/modules/generated/sklearn.model_selection.train_test_split.html).  This is probably a better solution, but I still need to run more tests before creating a new PR.

Note that in this PR I also set the TensorFlow seed -- it doesn't appear to be used, but it's good to have them all set to the same value for consistency. 