### PR TITLE
Ignore DeprecationWarning from flatbuffers.compat.

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+filterwarnings =
+    ignore:the imp module:DeprecationWarning:flatbuffers\.compat:


### PR DESCRIPTION
This PR adds a `pytest.ini` file that ignores the `flatbuffers.compat` warning about the `imp` module.

Some background in https://github.com/pytest-dev/pytest/discussions/8759#discussioncomment-2818984