### PR TITLE
Pass the seed to sklearn.model_selection.train_test_split.

### DIFF
--- a/karoo_gp/base_class.py
+++ b/karoo_gp/base_class.py
@@ -173,8 +173,9 @@ class Base_GP(object):
         # initialize RNG(s) with the given seed
         self.seed = seed
         self.rng = np.random.default_rng(seed)  # this is used by Karoo
-        np.random.seed(seed)  # this is used by sklearn while classifying
-        tf.set_random_seed(seed)  # this is not used, but set it just in case
+        # the following two are not used, set them just in case
+        np.random.seed(seed)  # this was used by sklearn while classifying
+        tf.set_random_seed(seed)
 
         ### PART 2 - construct first generation of Trees ###
         self.fx_data_load(filename)
@@ -521,7 +522,7 @@ class Base_GP(object):
             # if larger than 10, we run the data through the
             # SciKit Learn's 'random split' function
             x_train, x_test, y_train, y_test = skcv.train_test_split(
-                data_x, data_y, test_size=0.2
+                data_x, data_y, test_size=0.2, random_state=self.seed
             )  # 80/20 TRAIN/TEST split
             data_x, data_y = [], []  # clear from memory
 


### PR DESCRIPTION
This is a follow-up of #56.  I verified that by passing the seed to `sklearn.model_selection.train_test_split` the test results are consistent even when `np.random.seed` is not initialized.  I left its initialization just in case, with an updated comment.

I also tried to pass the rng directly, but got this error: `ValueError: Generator(PCG64) at 0x7F1758766A40 cannot be used to seed a numpy.random.RandomState instance`.