### PR TITLE
Add tests for the matching kernel.

### DIFF
--- a/karoo_gp/test/data/log_test[m-f].txt
+++ b/karoo_gp/test/data/log_test[m-f].txt
@@ -1,0 +1,11 @@
+Karoo GP
+ launched: 2022-05-29_11-56-44-303521
+ dataset: karoo_gp/files/data_MATCH.csv
+
+
+ Tree 50 is the most fit, with expression:
+
+ -a**2 + a*c - a + b + c
+
+ Matching fitness score: 10.0
+

--- a/karoo_gp/test/data/log_test[m-g].txt
+++ b/karoo_gp/test/data/log_test[m-g].txt
@@ -1,0 +1,11 @@
+Karoo GP
+ launched: 2022-05-29_11-55-27-152624
+ dataset: karoo_gp/files/data_MATCH.csv
+
+
+ Tree 27 is the most fit, with expression:
+
+ a + b + c
+
+ Matching fitness score: 10.0
+

--- a/karoo_gp/test/data/log_test[m-r].txt
+++ b/karoo_gp/test/data/log_test[m-r].txt
@@ -1,0 +1,11 @@
+Karoo GP
+ launched: 2022-05-29_11-56-15-803524
+ dataset: karoo_gp/files/data_MATCH.csv
+
+
+ Tree 4 is the most fit, with expression:
+
+ a + b + c
+
+ Matching fitness score: 10.0
+

--- a/karoo_gp/test/test_cli.py
+++ b/karoo_gp/test/test_cli.py
@@ -18,12 +18,15 @@ def parse_log(log_path, root_dir):
 
 
 @pytest.mark.parametrize('typ', ['f', 'g', 'r'])
-@pytest.mark.parametrize('ker', ['c', 'r'])
+@pytest.mark.parametrize('ker', ['c', 'r', 'm'])
 def test_cli(tmp_path, paths, ker, typ):
     """Test that the CLI yields consistent results with different kernels/trees."""
     data_file = paths.data_files[ker]  # get the right data file for the kernel
+    # default pop is 10, except for m-g and m-f that need higher pop to pass
+    pop = {('m', 'g'): 35, ('m', 'f'): 50}.get((ker, typ), 10)
+    seed = 1000
     cmd = ['python3', paths.karoo, '-ker', ker, '-typ', typ, '-bas', '3',
-           '-pop', '10', '-rsd', '1000', '-fil', data_file]
+           '-pop', str(pop), '-rsd', str(seed), '-fil', data_file]
     print(' '.join(map(str, cmd)))
     cp = subprocess.run(cmd, cwd=tmp_path)  # run Karoo in a tmp dir
     assert cp.returncode == 0  # check that the run was successful

--- a/karoo_gp/test/test_cli.py
+++ b/karoo_gp/test/test_cli.py
@@ -17,16 +17,17 @@ def parse_log(log_path, root_dir):
     return dataset, rest
 
 
+@pytest.mark.parametrize('seed', ['1000'])
+@pytest.mark.parametrize('bas', ['3'])
 @pytest.mark.parametrize('typ', ['f', 'g', 'r'])
 @pytest.mark.parametrize('ker', ['c', 'r', 'm'])
-def test_cli(tmp_path, paths, ker, typ):
+def test_cli(tmp_path, paths, ker, typ, bas, seed):
     """Test that the CLI yields consistent results with different kernels/trees."""
-    data_file = paths.data_files[ker]  # get the right data file for the kernel
     # default pop is 10, except for m-g and m-f that need higher pop to pass
-    pop = {('m', 'g'): 35, ('m', 'f'): 50}.get((ker, typ), 10)
-    seed = 1000
-    cmd = ['python3', paths.karoo, '-ker', ker, '-typ', typ, '-bas', '3',
-           '-pop', str(pop), '-rsd', str(seed), '-fil', data_file]
+    pop = str({('m', 'g'): 35, ('m', 'f'): 50}.get((ker, typ), 10))
+    data_file = paths.data_files[ker]  # get the right data file for the kernel
+    cmd = ['python3', paths.karoo, '-ker', ker, '-typ', typ, '-bas', bas,
+           '-pop', pop, '-rsd', seed, '-fil', data_file]
     print(' '.join(map(str, cmd)))
     cp = subprocess.run(cmd, cwd=tmp_path)  # run Karoo in a tmp dir
     assert cp.returncode == 0  # check that the run was successful


### PR DESCRIPTION
This PR adds tests for the matching kernel.

With grow and full trees and the default population of 10 the species went extinct, so I had to special case these two to use a higher population.  I tried looking into conditionally parametrize the tests but it seems the only way to do it would be to manually unroll the parameters and have 9 different entries instead of 2 entries with 3 parameters each.

With these values all tests still pass in ~100s on my machine.