### PR TITLE
Make the tf log level configurable and set it to 2.

### DIFF
--- a/karoo_gp/base_class.py
+++ b/karoo_gp/base_class.py
@@ -29,7 +29,14 @@ from . import pause as menu
 
 
 ### TensorFlow Imports and Definitions ###
-os.environ["TF_CPP_MIN_LOG_LEVEL"] = "1"
+if os.environ.get("TF_CPP_MIN_LOG_LEVEL") is None:
+    # Set the log level, unless it's already set in the env.
+    # This allows users to override this value with an env var.
+    # 0 = all messages are logged (default behavior)
+    # 1 = INFO messages are not printed
+    # 2 = INFO and WARNING messages are not printed
+    # 3 = INFO, WARNING, and ERROR messages are not printed
+    os.environ["TF_CPP_MIN_LOG_LEVEL"] = "2"  # only print ERRORs
 
 # import tensorflow as tf
 import tensorflow.compat.v1 as tf


### PR DESCRIPTION
This PR does two things:
1. it sets the default TensorFlow logging level to `2` (i.e. only `ERROR`s), hiding the following warning:
   ```
   2022-05-29 13:41:43.094655: W tensorflow/stream_executor/platform/default/dso_loader.cc:64]
      Could not load dynamic library 'libcudart.so.11.0'; dlerror: libcudart.so.11.0: cannot open shared object file: No such file or directory
   2022-05-29 13:41:43.094696: I tensorflow/stream_executor/cuda/cudart_stub.cc:29]
      Ignore above cudart dlerror if you do not have a GPU set up on your machine.
   ```
2. it makes the logging level configurable by setting the `TF_CPP_MIN_LOG_LEVEL` env var.  For example, you can show all the TF warnings by running `TF_CPP_MIN_LOG_LEVEL=1 karoo-gp.py ...`