### PR TITLE
Fix imports in __init__.py.

### DIFF
--- a/karoo_gp/__init__.py
+++ b/karoo_gp/__init__.py
@@ -1,3 +1,1 @@
-from .base_class import Base_GP
-
 __version__ = "2.4.0"

--- a/karoo_gp/test/test_base.py
+++ b/karoo_gp/test/test_base.py
@@ -2,7 +2,7 @@ import hashlib
 
 import pytest
 
-from karoo_gp import Base_GP
+from karoo_gp.base_class import Base_GP
 
 @pytest.fixture
 def default_kwargs(tmp_path):


### PR DESCRIPTION
This PR reverts a change that broke the release process.

Since the `__version__` is defined in the `__init__.py`, during the release the file is accessed to fetch the version number.  However, if the file imports `base_class.py` or other files, importing `__init__.py` will in turn trigger other imports that will require other dependency (such as `numpy`) and the import and the whole release process will fail.

I removed all the imports from `__init__.py` and adjusted another import in a test (which afaik is the only one that relied on `Base_GP` being import in `__init__.py`.  In the future we could use a different approach for storing the `__version__` if we want to be able to import things directly from `karoo_gp`.