### PR TITLE
Use Unicode-art for the tree display.

### DIFF
--- a/karoo_gp/branch.py
+++ b/karoo_gp/branch.py
@@ -263,6 +263,7 @@ class Branch:
             for (branch, branch_width) in last_children:
                 symbol = ' ' if branch is None else str(branch.node.symbol)[:symbol_max_len]
                 this_output = symbol.center(branch_width)
+                symbol_index = this_output.find(symbol)
                 this_children = []      # Children from this item
                 cum_width = 0           # Cumulative character-width of all subtrees
                 cum_cols = 0            # Cumulative maximum node-width of all subtrees
@@ -286,12 +287,16 @@ class Branch:
                         this_children.append((child, child_width))
                         cum_width += child_width
                     # Add lines to the output
-                    start_padding = this_children[0][1] // 2          # Midpoint of first child
+                    start_padding = this_children[0][1] // 2 - 1  # Midpoint of first child
                     end_padding = branch_width - (this_children[-1][1] // 2)  # ..of last child
-                    with_line = ''
-                    for i, v in enumerate(this_output):
-                        with_line += '_' if (i > start_padding and i < end_padding and v == ' ') else v
-                    this_output = with_line
+                    with_line = ['─' if (i > start_padding and i < end_padding and v == ' ') else v
+                                 for i, v in enumerate(this_output)]
+                    if len(with_line) > 3:
+                        with_line[start_padding] = '╭' # '┌'
+                        with_line[symbol_index-1] = '┤'
+                        with_line[symbol_index+1] = '├'
+                        with_line[end_padding-1] = '╮' # '┐'
+                    this_output = ''.join(with_line)
                 depth_output += this_output
                 depth_children += this_children
             last_children = depth_children


### PR DESCRIPTION
This PR is a proof of concept that updates the `Branch.display_viz()` method to use Unicode-art instead of ASCII-art.

This is an example of the new representation:
```
                       ╭────┤+├──────────────────────╮      
           ╭──────────┤+├──────────╮                 b      
     ╭────┤+├────╮           ╭────┤+├────╮                  
     b           b           c           a           
```
Or as a screenshot from my terminal:
![image](https://user-images.githubusercontent.com/25624924/182723607-6a1b1493-fa92-4cfc-b7b5-3cd0d8dc3ae2.png)

I also played around with a few different representations:
1. without rounded corners and nothing around the operator:
   ```
     ┌───────────────────────*─────┐                        
     a                       ┌─────*─────────────────┐      
                 ┌───────────-─────┐                 a      
                 b           ┌─────-─────┐                  
                             a           a     
   ```
2. with rounded corners and nothing around the operator:
   ```
                   ╭─────────/───────────────────╮          
              ╭────*──────────────╮         ╭────+────╮     
    ╭─────────-────╮              c         c         b     
    a         ╭────/────╮                                   
              a         c   

   ```
3. with rounded corners and `[ ]` around the operators:
   ```
                        ╭───[+]───────────────────────╮     
    ╭──────────────────[-]───╮                        c     
    b              ╭────────[+]────────╮                    
              ╭───[-]───╮         ╭───[-]───╮               
              b         c         a         c  
   ```
4. with rounded corners and `┤ ├` around the operators (the proposed one, shown at the top).

TODO:
- [x] decide which representation to adopt
- [ ] fix tests accordingly
- [ ] possibly add a `unicode=True` arg

There are also a few items that don't seem directly related to this PR, but should be fixed in a separate PR:
- [ ] fix some alignment issues
- [ ] handle functions/operators with len > 1
- [ ] handle deep tree